### PR TITLE
Disable trailing whitespace auto-deletion

### DIFF
--- a/scoped-properties/language-slim.cson
+++ b/scoped-properties/language-slim.cson
@@ -1,3 +1,6 @@
 '.text.slim':
   'editor':
     'commentStart': '/ '
+  whitespace: 
+    removeTrailingWhitespace: false
+    ignoreWhitespaceOnCurrentLine: false


### PR DESCRIPTION
Slim files sometimes require trailing whitespace. End this being removed