### PR TITLE
Associate 'emblem' extenstion.

### DIFF
--- a/grammars/ruby slim.cson
+++ b/grammars/ruby slim.cson
@@ -1,6 +1,7 @@
 'fileTypes': [
   'slim'
   'skim'
+  'emblem'
 ]
 'foldingStartMarker': '^\\s*([-%#\\:\\.\\w\\=].*)\\s$'
 'foldingStopMarker': '^\\s*$'


### PR DESCRIPTION
There's a javascript library called Emblem.js that's fairly widely used, whose syntax follows slim exactly. Those of us who use it just tell our IDE's to use slim syntax highlighting for `.emblem` files, but unfortunately with Atom that change needs to made at the package leve.