### PR TITLE
Fixes embedded  syntax highlighting

### DIFF
--- a/grammars/ruby slim.cson
+++ b/grammars/ruby slim.cson
@@ -8,6 +8,19 @@
 'name': 'Ruby Slim'
 'patterns': [
   {
+    'begin': '^(\\s*)(ruby):$'
+    'beginCaptures':
+      '2':
+        'name': 'constant.language.name.ruby.filter.slim'
+    'end': '^(?!(\\1\\s)|\\s*$)'
+    'name': 'text.ruby.filter.slim'
+    'patterns': [
+      {
+        'include': 'source.ruby'
+      }
+    ]
+  },
+  {
     'begin': '^(\\s*)(javascript):$'
     'beginCaptures':
       '2':


### PR DESCRIPTION
Fixes embedded ruby syntax highlighting.

## Before
![screen shot 2017-03-03 at 3 13 29 pm](https://cloud.githubusercontent.com/assets/727774/23567411/1ccba6a0-0024-11e7-8de7-4301636f115e.png)

## After
![screen shot 2017-03-03 at 3 11 51 pm](https://cloud.githubusercontent.com/assets/727774/23567420/2607ae6c-0024-11e7-8f67-b8c6c6f00222.png)

