### PR TITLE
update grammar and snippets from ruby-slim.tmbundle

### DIFF
--- a/grammars/ruby slim.cson
+++ b/grammars/ruby slim.cson
@@ -1,432 +1,470 @@
-'fileTypes': [
-  'slim'
-  'skim'
-  'emblem'
+fileTypes: [
+  "slim"
+  "skim"
 ]
-'foldingStartMarker': '^\\s*([-%#\\:\\.\\w\\=].*)\\s$'
-'foldingStopMarker': '^\\s*$'
-'name': 'Ruby Slim'
-'patterns': [
+foldingStartMarker: "^\\s*([-%#\\:\\.\\w\\=].*)\\s$"
+foldingStopMarker: "^\\s*$"
+name: "Ruby Slim"
+patterns: [
   {
-    'begin': '^(\\s*)(ruby):$'
-    'beginCaptures':
-      '2':
-        'name': 'constant.language.name.ruby.filter.slim'
-    'end': '^(?!(\\1\\s)|\\s*$)'
-    'name': 'text.ruby.filter.slim'
-    'patterns': [
+    begin: "^(\\s*)(ruby):$"
+    beginCaptures:
+      "2":
+        name: "constant.language.name.ruby.filter.slim"
+    end: "^(?!(\\1\\s)|\\s*$)"
+    name: "text.ruby.filter.slim"
+    patterns: [
       {
-        'include': 'source.ruby'
-      }
-    ]
-  },
-  {
-    'begin': '^(\\s*)(javascript):$'
-    'beginCaptures':
-      '2':
-        'name': 'constant.language.name.javascript.filter.slim'
-    'end': '^(?!(\\1\\s)|\\s*$)'
-    'name': 'text.javascript.filter.slim'
-    'patterns': [
-      {
-        'include': 'source.js'
+        include: "source.ruby"
       }
     ]
   }
   {
-    'begin': '^(\\s*)(coffee):$'
-    'beginCaptures':
-      '2':
-        'name': 'constant.language.name.coffeescript.filter.slim'
-    'end': '^(?!(\\1\\s)|\\s*$)'
-    'name': 'text.coffeescript.filter.slim'
-    'patterns': [
+    begin: "^(\\s*)(javascript):$"
+    beginCaptures:
+      "2":
+        name: "constant.language.name.javascript.filter.slim"
+    end: "^(?!(\\1\\s)|\\s*$)"
+    name: "source.js.filter.slim"
+    patterns: [
       {
-        'include': 'source.coffee'
+        include: "source.js"
       }
     ]
   }
   {
-    'begin': '^(\\s*)(markdown):$'
-    'beginCaptures':
-      '2':
-        'name': 'constant.language.name.markdown.filter.slim'
-    'end': '^(?!(\\1\\s)|\\s*$)'
-    'name': 'text.markdown.filter.slim'
-    'patterns': [
+    begin: "^(---)\\s*\\n"
+    beginCaptures:
+      "1":
+        name: "storage.frontmatter.slim"
+    end: "^(---)\\s*\\n"
+    endCaptures:
+      "1":
+        name: "storage.frontmatter.slim"
+    name: "source.yaml.meta.slim"
+    patterns: [
       {
-        'include': 'source.md'
+        include: "source.yaml"
       }
     ]
   }
   {
-    'begin': '^(\\s*)(css):$'
-    'beginCaptures':
-      '2':
-        'name': 'constant.language.name.css.filter.slim'
-    'end': '^(?!(\\1\\s)|\\s*$)'
-    'name': 'text.css.filter.slim'
-    'patterns': [
+    begin: "^(\\s*)(coffee):$"
+    beginCaptures:
+      "2":
+        name: "constant.language.name.coffeescript.filter.slim"
+    end: "^(?!(\\1\\s)|\\s*$)"
+    name: "text.coffeescript.filter.slim"
+    patterns: [
       {
-        'include': 'source.css'
+        include: "source.coffee"
       }
     ]
   }
   {
-    'begin': '^(\\s*)(sass):$'
-    'beginCaptures':
-      '2':
-        'name': 'constant.language.name.sass.filter.slim'
-    'end': '^(?!(\\1\\s)|\\s*$)'
-    'name': 'text.sass.filter.slim'
-    'patterns': [
+    begin: "^(\\s*)(markdown):$"
+    beginCaptures:
+      "2":
+        name: "constant.language.name.markdown.filter.slim"
+    end: "^(?!(\\1\\s)|\\s*$)"
+    name: "text.markdown.filter.slim"
+    patterns: [
       {
-        'include': 'source.sass'
+        include: "text.html.markdown"
       }
     ]
   }
   {
-    'begin': '^(\\s*)(scss):$'
-    'beginCaptures':
-      '2':
-        'name': 'constant.language.name.scss.filter.slim'
-    'end': '^(?!(\\1\\s)|\\s*$)'
-    'name': 'text.scss.filter.slim'
-    'patterns': [
+    begin: "^(\\s*)(css):$"
+    beginCaptures:
+      "2":
+        name: "constant.language.name.css.filter.slim"
+    end: "^(?!(\\1\\s)|\\s*$)"
+    name: "text.css.filter.slim"
+    patterns: [
       {
-        'include': 'source.sass'
+        include: "source.css"
       }
     ]
   }
   {
-    'captures':
-      '1':
-        'name': 'punctuation.definition.prolog.slim'
-    'match': '^(! )($|\\s.*)'
-    'name': 'meta.prolog.slim'
-  }
-  {
-    'captures':
-      '1':
-        'name': 'punctuation.section.comment.slim'
-    'match': '^\\s*(/)\\s*\\S.*$\\n?'
-    'name': 'comment.line.slash.slim'
-  }
-  {
-    'begin': '^(\\s*)(/)\\s*$'
-    'beginCaptures':
-      '2':
-        'name': 'punctuation.section.comment.slim'
-    'end': '^(?!\\1  )'
-    'name': 'comment.block.slim'
-    'patterns': [
+    begin: "^(\\s*)(sass):$"
+    beginCaptures:
+      "2":
+        name: "constant.language.name.sass.filter.slim"
+    end: "^(?!(\\1\\s)|\\s*$)"
+    name: "text.sass.filter.slim"
+    patterns: [
       {
-        'include': 'text.slim'
+        include: "source.sass"
       }
     ]
   }
   {
-    'begin': '^\\s*(?===|=|-|~)'
-    'end': '$'
-    'patterns': [
+    begin: "^(\\s*)(scss):$"
+    beginCaptures:
+      "2":
+        name: "constant.language.name.scss.filter.slim"
+    end: "^(?!(\\1\\s)|\\s*$)"
+    name: "text.scss.filter.slim"
+    patterns: [
       {
-        'include': '#rubyline'
+        include: "source.scss"
       }
     ]
   }
   {
-    'include': '#inline-html-tag'
-  }
-  {
-    'include': '#normal-html-tag'
-  }
-  {
-    'include': '#embedded-ruby'
-  }
-  {
-    'begin': '^\\s*([\\w.#_-]*[\\w]+)\\s*'
-    'captures':
-      '0':
-        'name': 'entity.name.tag.slim'
-    'end': '$|(?!\\.|#|\\{|\\[|=|-|~|/)'
-    'patterns': [
+    begin: "^(\\s*)(less):$"
+    beginCaptures:
+      "2":
+        name: "constant.language.name.less.filter.slim"
+    end: "^(?!(\\1\\s)|\\s*$)"
+    name: "text.less.filter.slim"
+    patterns: [
       {
-        'begin': '\\{(?=.*\\}|.*\\|\\s*$)'
-        'end': '\\}|$|^(?!.*\\|\\s*$)'
-        'name': 'meta.section.attributes.slim'
-        'patterns': [
+        include: "source.less"
+      }
+    ]
+  }
+  {
+    begin: "^(\\s*)(erb):$"
+    beginCaptures:
+      "2":
+        name: "constant.language.name.erb.filter.slim"
+    end: "^(?!(\\1\\s)|\\s*$)"
+    name: "text.erb.filter.slim"
+    patterns: [
+      {
+        include: "source.erb"
+      }
+    ]
+  }
+  {
+    captures:
+      "1":
+        name: "punctuation.definition.prolog.slim"
+    match: "^(! )($|\\s.*)"
+    name: "meta.prolog.slim"
+  }
+  {
+    begin: "^(\\s*)(/)\\s*.*$"
+    beginCaptures:
+      "2":
+        name: "comment.line.slash.slim"
+    end: "^(?!(\\1\\s)|\\s*$)"
+    name: "comment.block.slim"
+  }
+  {
+    begin: "^\\s*(?=-)"
+    end: "$"
+    patterns: [
+      {
+        include: "#rubyline"
+      }
+    ]
+  }
+  {
+    begin: "(?==+|~)"
+    end: "$"
+    patterns: [
+      {
+        include: "#rubyline"
+      }
+    ]
+  }
+  {
+    include: "#tag-attribute"
+  }
+  {
+    include: "#embedded-ruby"
+  }
+  {
+    begin: "^(\\s*)(\\||')\\s*"
+    comment: "Verbatim text (can include HTML tags and copied lines)"
+    end: "^(?!(\\1\\s)|\\s*$)"
+    patterns: [
+      {
+        include: "text.html.basic"
+      }
+      {
+        include: "#embedded-ruby"
+      }
+    ]
+  }
+  {
+    begin: "^\\s*(\\.|#|[-a-zA-Z0-9]+)([\\w-]+)?"
+    captures:
+      "1":
+        name: "entity.name.tag.slim"
+      "2":
+        name: "entity.other.attribute-name.event.slim"
+    comment: "1 - dot OR hash OR any combination of word, number; 2 - OPTIONAL any combination of word, number, dash or underscore (following a . or"
+    end: "$|(?!\\.|#|:|-|~|/|\\}|\\]|\\*|\\s?[\\*\\{])"
+    name: "meta.tag"
+    patterns: [
+      {
+        begin: "(:[\\w\\d]+)+"
+        comment: "XML"
+        end: "$|\\s"
+        name: "entity.name.tag.slim"
+      }
+      {
+        begin: "(:\\s)(\\.|#|[a-zA-Z0-9]+)([\\w-]+)?"
+        captures:
+          "1":
+            name: "punctuation.definition.tag.end.slim"
+          "2":
+            name: "entity.name.tag.slim"
+          "3":
+            name: "entity.other.attribute-name.event.slim"
+        comment: "Inline HTML / 1 - colon; 2 - dot OR hash OR any combination of word, number; 3 - OPTIONAL any combination of word, number, dash or underscore (following a . or"
+        end: "$|(?!\\.|#|=|-|~|/|\\}|\\]|\\*|\\s?[\\*\\{])"
+        patterns: [
           {
-            'include': 'source.ruby.rails'
+            include: "#root-class-id-tag"
           }
           {
-            'include': '#continuation'
+            include: "#tag-attribute"
           }
         ]
       }
       {
-        'begin': '\\[(?=.*\\]|.*\\|\\s*$)'
-        'end': '\\]|$|^(?!.*\\|\\s*$)'
-        'name': 'meta.section.object.slim'
-        'patterns': [
+        begin: "(\\*\\{)(?=.*\\}|.*\\|\\s*$)"
+        beginCaptures:
+          "1":
+            name: "punctuation.section.embedded.ruby"
+        comment: "Splat attributes"
+        end: "(\\})|$|^(?!.*\\|\\s*$)"
+        endCaptures:
+          "1":
+            name: "punctuation.section.embedded.ruby"
+        name: "source.ruby.embedded.slim"
+        patterns: [
           {
-            'include': 'source.ruby.rails'
-          }
-          {
-            'include': '#continuation'
+            include: "#embedded-ruby"
           }
         ]
       }
       {
-        'include': '#rubyline'
+        include: "#root-class-id-tag"
       }
       {
-        'match': '/'
-        'name': 'punctuation.terminator.tag.slim'
+        include: "#rubyline"
+      }
+      {
+        match: "/"
+        name: "punctuation.terminator.tag.slim"
       }
     ]
   }
   {
-    'captures':
-      '1':
-        'name': 'meta.escape.slim'
-    'match': '^\\s*(\\\\.)'
+    captures:
+      "1":
+        name: "meta.escape.slim"
+    match: "^\\s*(\\\\.)"
   }
   {
-    'begin': '^\\s*(?=\\||\')'
-    'end': '$'
-    'patterns': [
+    begin: "^\\s*(?=\\||')"
+    end: "$"
+    patterns: [
       {
-        'include': '#embedded-ruby'
+        include: "#embedded-ruby"
       }
       {
-        'include': 'text.html.basic'
+        include: "text.html.basic"
+      }
+    ]
+  }
+  {
+    begin: "(?=<[\\w\\d\\:]+)"
+    comment: "Inline and root-level HTML tags"
+    end: "$|\\/\\>"
+    patterns: [
+      {
+        include: "text.html.basic"
       }
     ]
   }
 ]
-'repository':
-  'continuation':
-    'captures':
-      '1':
-        'name': 'punctuation.separator.continuation.slim'
-    'match': '([\\\\,])\\s*\\n'
-  'delimited-ruby-a':
-    'begin': '=\\('
-    'end': '\\)(?=( \\w|$))'
-    'name': 'source.ruby.embedded.slim'
-    'patterns': [
+repository:
+  continuation:
+    captures:
+      "1":
+        name: "punctuation.separator.continuation.slim"
+    match: "([\\\\,])\\s*\\n"
+  "delimited-ruby-a":
+    begin: "=\\("
+    end: "\\)(?=( \\w|$))"
+    name: "source.ruby.embedded.slim"
+    patterns: [
       {
-        'include': 'source.ruby.rails'
+        include: "source.ruby.rails"
       }
     ]
-  'delimited-ruby-b':
-    'begin': '=\\['
-    'end': '\\](?=( \\w|$))'
-    'name': 'source.ruby.embedded.slim'
-    'patterns': [
+  "delimited-ruby-b":
+    begin: "=\\["
+    end: "\\](?=( \\w|$))"
+    name: "source.ruby.embedded.slim"
+    patterns: [
       {
-        'include': 'source.ruby.rails'
+        include: "source.ruby.rails"
       }
     ]
-  'delimited-ruby-c':
-    'begin': '=\\{'
-    'end': '\\}(?=( \\w|$))'
-    'name': 'source.ruby.embedded.slim'
-    'patterns': [
+  "delimited-ruby-c":
+    begin: "=\\{"
+    end: "\\}(?=( \\w|$))"
+    name: "source.ruby.embedded.slim"
+    patterns: [
       {
-        'include': 'source.ruby.rails'
+        include: "source.ruby.rails"
       }
     ]
-  'embedded-ruby':
-    'begin': '(?<!\\\\)#\\{{1,2}'
-    'beginCaptures':
-      '0':
-        'name': 'punctuation.section.embedded.ruby'
-    'end': '\\}{1,2}'
-    'endCaptures':
-      '0':
-        'name': 'punctuation.section.embedded.ruby'
-    'name': 'source.ruby.embedded.html'
-    'patterns': [
+  "embedded-ruby":
+    begin: "(?<!\\\\)#\\{{1,2}"
+    beginCaptures:
+      "0":
+        name: "punctuation.section.embedded.ruby"
+    end: "\\}{1,2}"
+    endCaptures:
+      "0":
+        name: "punctuation.section.embedded.ruby"
+    name: "source.ruby.embedded.html"
+    patterns: [
       {
-        'include': 'source.ruby.rails'
+        include: "source.ruby.rails"
       }
     ]
-  'entities':
-    'patterns': [
+  entities:
+    patterns: [
       {
-        'captures':
-          '1':
-            'name': 'punctuation.definition.entity.html'
-          '3':
-            'name': 'punctuation.definition.entity.html'
-        'match': '(&)([a-zA-Z0-9]+|#[0-9]+|#x[0-9a-fA-F]+)(;)'
-        'name': 'constant.character.entity.html'
+        captures:
+          "1":
+            name: "punctuation.definition.entity.html"
+          "3":
+            name: "punctuation.definition.entity.html"
+        match: "(&)([a-zA-Z0-9]+|#[0-9]+|#x[0-9a-fA-F]+)(;)"
+        name: "constant.character.entity.html"
       }
       {
-        'match': '&'
-        'name': 'invalid.illegal.bad-ampersand.html'
-      }
-    ]
-  'inline-html-tag':
-    'begin': '^(\\s*([\\w.#_-]+( [\\w.#_-]+=(".*?"))*: )*)([\\w.#_-]+( [\\w.#_-]+=(".*?"))*:)(?=\\s)'
-    'captures':
-      '1':
-        'name': 'entity.name.tag.slim'
-      '2':
-        'name': 'entity.name.tag.slim'
-      '3':
-        'name': 'entity.name.tag.slim'
-      '4':
-        'name': 'string.quoted.double.html'
-      '5':
-        'name': 'entity.name.tag.slim'
-      '6':
-        'name': 'entity.name.tag.slim'
-      '7':
-        'name': 'string.quoted.double.html'
-    'end': '$'
-    'patterns': [
-      {
-        'include': '#normal-inline-html-tag'
-      }
-      {
-        'include': '#tag-stuff'
+        match: "&"
+        name: "invalid.illegal.bad-ampersand.html"
       }
     ]
-  'interpolated-ruby':
-    'begin': '=(?=\\b)'
-    'end': '\\s|\\w$'
-    'name': 'source.ruby.embedded.html'
-  'normal-html-tag':
-    'begin': '([\\w.#_-]+=)'
-    'captures':
-      '1':
-        'name': 'entity.name.tag.slim'
-    'end': '$'
-    'patterns': [
+  "interpolated-ruby":
+    begin: "=(?=\\b)"
+    end: "\\s|\\w$"
+    name: "source.ruby.embedded.html"
+  "root-class-id-tag":
+    captures:
+      "1":
+        name: "punctuation.separator.key-value.html"
+      "2":
+        name: "entity.other.attribute-name.html"
+    match: "(\\.|#)([\\w\\d\\-]+)"
+  rubyline:
+    begin: "(==|=)(<>|><|<'|'<|<|>)?|-"
+    comment: "Hack to thwart Sublime's Ruby highlighter. It thinks do without a variable continues the next line (this can be muted with a / at the end of the line). For things like yields, do is unnecessary without an argument, so this hack will suffice"
+    contentName: "source.ruby.embedded.slim"
+    end: "(do\\s*\\n$)|(?<!\\\\|,|,\\n|\\\\\\n)$"
+    endCaptures:
+      "1":
+        name: "keyword.control.start-block.ruby"
+    name: "meta.line.ruby.slim"
+    patterns: [
       {
-        'include': '#tag-stuff'
+        comment: "Hack to let ruby comments work in this context properly"
+        match: "#.*$"
+        name: "comment.line.number-sign.ruby"
       }
       {
-        'include': '#string-double-quoted'
+        include: "#continuation"
       }
       {
-        'include': '#string-single-quoted'
-      }
-    ]
-  'normal-inline-html-tag':
-    'begin': '([\\w.#_-]+)'
-    'captures':
-      '1':
-        'name': 'entity.name.tag.slim'
-    'end': '$'
-    'patterns': [
-      {
-        'include': '#tag-stuff'
-      }
-    ]
-  'rubyline':
-    'begin': '(==|=)(<>|><|<\'|\'<|<|>|\')?|-'
-    'contentName': 'source.ruby.embedded.slim'
-    'end': '(?<!\\\\|,)$'
-    'name': 'meta.line.ruby.slim'
-    'patterns': [
-      {
-        'comment': 'Hack to let ruby comments work in this context properly'
-        'match': '#.*$'
-        'name': 'comment.line.number-sign.ruby'
-      }
-      {
-        'include': '#continuation'
-      }
-      {
-        'include': 'source.ruby.rails'
+        include: "source.ruby.rails"
       }
     ]
-  'string-double-quoted':
-    'begin': '"'
-    'beginCaptures':
-      '0':
-        'name': 'punctuation.definition.string.begin.html'
-    'contentName': 'meta.toc-list.id.html'
-    'end': '"'
-    'endCaptures':
-      '0':
-        'name': 'punctuation.definition.string.end.html'
-    'name': 'string.quoted.double.html'
-    'patterns': [
+  "string-double-quoted":
+    begin: "(\")(?=.*\")"
+    beginCaptures:
+      "0":
+        name: "punctuation.definition.string.begin.html"
+    contentName: "meta.toc-list.id.html"
+    end: "\""
+    endCaptures:
+      "0":
+        name: "punctuation.definition.string.end.html"
+    name: "string.quoted.double.html"
+    patterns: [
       {
-        'include': '#embedded-ruby'
+        include: "#embedded-ruby"
       }
       {
-        'include': '#entities'
-      }
-    ]
-  'string-single-quoted':
-    'begin': '\''
-    'beginCaptures':
-      '0':
-        'name': 'punctuation.definition.string.begin.html'
-    'contentName': 'meta.toc-list.id.html'
-    'end': '\''
-    'endCaptures':
-      '0':
-        'name': 'punctuation.definition.string.end.html'
-    'name': 'string.quoted.single.html'
-    'patterns': [
-      {
-        'include': '#embedded-ruby'
-      }
-      {
-        'include': '#entities'
+        include: "#entities"
       }
     ]
-  'tag-id-attribute':
-    'begin': '\\b(id)\\b\\s*(=)'
-    'captures':
-      '1':
-        'name': 'entity.other.attribute-name.id.html'
-      '2':
-        'name': 'punctuation.separator.key-value.html'
-    'end': '(?<=\'|")'
-    'name': 'meta.attribute-with-value.id.html'
-    'patterns': [
+  "string-single-quoted":
+    begin: "(')(?=.*')"
+    beginCaptures:
+      "0":
+        name: "punctuation.definition.string.begin.html"
+    contentName: "meta.toc-list.id.html"
+    end: "'"
+    endCaptures:
+      "0":
+        name: "punctuation.definition.string.end.html"
+    name: "string.quoted.single.html"
+    patterns: [
       {
-        'include': '#string-double-quoted'
+        include: "#embedded-ruby"
       }
       {
-        'include': '#string-single-quoted'
-      }
-    ]
-  'tag-stuff':
-    'patterns': [
-      {
-        'include': '#inline-html-tag'
-      }
-      {
-        'include': '#normal-html-tag'
-      }
-      {
-        'include': '#tag-id-attribute'
-      }
-      {
-        'include': '#interpolated-ruby'
-      }
-      {
-        'include': '#delimited-ruby-a'
-      }
-      {
-        'include': '#delimited-ruby-b'
-      }
-      {
-        'include': '#delimited-ruby-c'
-      }
-      {
-        'include': '#rubyline'
-      }
-      {
-        'include': '#embedded-ruby'
+        include: "#entities"
       }
     ]
-'scopeName': 'text.slim'
+  "tag-attribute":
+    begin: "([\\w.#_-]+)(=)(?!\\s)(true|false|nil)?(\\s*\\(|\\{)?"
+    captures:
+      "1":
+        name: "entity.other.attribute-name.event.slim"
+      "2":
+        name: "punctuation.separator.key-value.html"
+      "3":
+        name: "constant.language.slim"
+    end: "\\}|\\)|$"
+    name: "meta.attribute-with-value.slim"
+    patterns: [
+      {
+        include: "#tag-stuff"
+      }
+      {
+        include: "#string-double-quoted"
+      }
+      {
+        include: "#string-single-quoted"
+      }
+    ]
+  "tag-stuff":
+    patterns: [
+      {
+        include: "#tag-attribute"
+      }
+      {
+        include: "#interpolated-ruby"
+      }
+      {
+        include: "#delimited-ruby-a"
+      }
+      {
+        include: "#delimited-ruby-b"
+      }
+      {
+        include: "#delimited-ruby-c"
+      }
+      {
+        include: "#rubyline"
+      }
+      {
+        include: "#embedded-ruby"
+      }
+    ]
+scopeName: "text.slim"

--- a/grammars/ruby slim.cson
+++ b/grammars/ruby slim.cson
@@ -363,9 +363,9 @@ repository:
     match: "(\\.|#)([\\w\\d\\-]+)"
   rubyline:
     begin: "(==|=)(<>|><|<'|'<|<|>)?|-"
-    comment: "Hack to thwart Sublime's Ruby highlighter. It thinks do without a variable continues the next line (this can be muted with a / at the end of the line). For things like yields, do is unnecessary without an argument, so this hack will suffice"
+    comment: "Hack to thwart Atom's Ruby highlighter. It thinks do without a variable continues the next line (this can be muted with a / at the end of the line). For things like yields, do is unnecessary without an argument, so this hack will suffice"
     contentName: "source.ruby.embedded.slim"
-    end: "(do\\s*\\n$)|(?<!\\\\|,|,\\n|\\\\\\n)$"
+    end: "(do\s*$)|(?<!\\\\|,|,\\n|\\\\\\n)$"
     endCaptures:
       "1":
         name: "keyword.control.start-block.ruby"

--- a/snippets/language-slim.cson
+++ b/snippets/language-slim.cson
@@ -1,133 +1,232 @@
-'.text.slim':
-  'HTML 5':
-    'prefix': 'doctype'
-    'body': 'doctype 5'
-  'XHTML 1.0 Strict':
-    'prefix': 'doctype'
-    'body': 'doctype strict'
-  'XHTML 1.0 Transitional':
-    'prefix': 'doctype'
-    'body': 'doctype transitional'
-  'XHTML 1.1':
-    'prefix': 'doctype'
-    'body': 'doctype 1.1'
-  '.columns':
-    'prefix': '.c'
-    'body': '.columns.clearfix\n\t.column.one\n\t.column.two\n\t.column.three'
-  'a':
-    'prefix': 'a'
-    'body': 'a href="${1:/}"$0'
-  'blockquote':
-    'prefix': 'b'
-    'body': 'blockquote'
-  'br':
-    'prefix': 'br'
-    'body': 'br\n\t'
-  'div (class)':
-    'prefix': '.'
-    'body': '.${1:class_selector}\n\t$0'
-  'div (id)':
-    'prefix': '#'
-    'body': '#${1:id_selector}\n\t$0'
-  'emphasized':
-    'prefix': 'e'
-    'body': 'em $0'
-  'filter (erb)':
-    'prefix': ':f'
-    'body': 'erb:\n\t$0'
-  'filter (escaped)':
-    'prefix': ':f'
-    'body': 'escaped:\n\t$0'
-  'filter (javascript)':
-    'prefix': ':f'
-    'body': 'javascript:\n\t$0'
-  'filter (markdown)':
-    'prefix': ':f'
-    'body': 'markdown:\n\t$0'
-  'filter (plain)':
-    'prefix': ':f'
-    'body': 'plain:\n\t$0'
-  'filter (preserve)':
-    'prefix': ':f'
-    'body': 'preserve:\n\t$0'
-  'filter (ruby)':
-    'prefix': ':f'
-    'body': 'ruby:\n\t$0'
-  'filter (sass)':
-    'prefix': ':f'
-    'body': 'sass:\n\t$0'
-  'filter (textile)':
-    'prefix': ':f'
-    'body': 'textile:\n\t$0'
-  'h1':
-    'prefix': 'h'
-    'body': 'h1 ${1:Heading Level 1}\n$0'
-  'h2':
-    'prefix': 'h'
-    'body': 'h2 ${1:Heading Level 2}\n$0'
-  'h3':
-    'prefix': 'h'
-    'body': 'h3 ${1:Heading Level 3}\n$0'
-  'h4':
-    'prefix': 'h'
-    'body': 'h4 ${1:Heading Level 4}\n$0'
-  'h5':
-    'prefix': 'h'
-    'body': 'h5 ${1:Heading Level 5}\n$0'
-  'h6':
-    'prefix': 'h'
-    'body': 'h6 ${1:Heading Level 6}\n$0'
-  'li':
-    'prefix': 'li'
-    'body': 'li ${5:Lorem ipsum...}$0'
-  'link_to (route)':
-    'prefix': '='
-    'body': '= link_to "${1:Anchor Text}", ${2:route}_url'
-  'link_to (url)':
-    'prefix': '='
-    'body': '= link_to "${1:Anchor Text}", "${2:#}"'
-  'link_to (wrap selected text)':
-    'prefix': '='
-    'body': '= link_to "Anchor text...", ${1:"${2:$0}"}'
-  'ol':
-    'prefix': 'ol'
-    'body': 'ol${1:#${2:selector}}\n\tli ${3:Lorem ipsum dolor sit amet, consectetur adipisicing elit.}$0'
-  'p':
-    'prefix': 'p'
-    'body': 'p ${1:Lorem ipsum...}'
-  'render_partial':
-    'prefix': '='
-    'body': '= render partial="${1:partial_name}"'
-  'span':
-    'prefix': 's'
-    'body': 'span $0'
-  'strong':
-    'prefix': 's'
-    'body': 'strong $0'
-  'table (basic)':
-    'prefix': 't'
-    'body': 'table\n\ttr\n\t\ttd\n\t\t\t${1:Table Data}'
-  'table (templated)':
-    'prefix': 't'
-    'body': 'table\n\tthead\n\t\ttr\n\t\t\tth\n\t\t\t${1:Table Heading}\n\ttbody\n\t\ttr\n\t\t\ttd\n\t\t\t\t${2:Table Data}'
-  'tbody':
-    'prefix': 't'
-    'body': 'tbody\n\ttr\n\t\ttd\n\t\t\t${1:Table Data} $0'
-  'td':
-    'prefix': 'td'
-    'body': 'td $0'
-  'tfooter':
-    'prefix': 't'
-    'body': 'tfoot\n\ttr\n\t\ttd\n\t\t\t${1:Table Data} $0'
-  'th':
-    'prefix': 'th'
-    'body': 'th $0'
-  'thead':
-    'prefix': 't'
-    'body': 'thead\n\ttr\n\t\tth\n\t\t\t${1:Table Heading} $0'
-  'tr':
-    'prefix': 'tr'
-    'body': 'tr\n\t${1:td}\n\t\t${2:Table Data} $0'
-  'ul':
-    'prefix': 'ul'
-    'body': 'ul${1:#${2:selector}}\n\tli ${3:Lorem ipsum dolor sit amet, consectetur adipisicing elit.}$0'
+".text.slim":
+  "HTML 5":
+    prefix: "doctype"
+    body: "doctype 5"
+  "XHTML 1.0 Strict":
+    prefix: "doctype"
+    body: "doctype strict"
+  "XHTML 1.0 Transitional":
+    prefix: "doctype"
+    body: "doctype transitional"
+  "XHTML 1.1":
+    prefix: "doctype"
+    body: "doctype 1.1"
+  ".columns":
+    prefix: ".c"
+    body: '''
+      .columns.clearfix
+        .column.one
+        .column.two
+        .column.three
+    '''
+  a:
+    prefix: "a"
+    body: "a href=\"${1:/}\"$0"
+  blockquote:
+    prefix: "b"
+    body: "blockquote"
+  br:
+    prefix: "br"
+    body: '''
+      br
+
+    '''
+  "div (class)":
+    prefix: "."
+    body: '''
+      .${1:class_selector}
+        $0
+    '''
+  "div (id)":
+    prefix: "#"
+    body: '''
+      #${1:id_selector}
+        $0
+    '''
+  emphasized:
+    prefix: "e"
+    body: "em $0"
+  "filter (erb)":
+    prefix: ":f"
+    body: '''
+      erb:
+        $0
+    '''
+  "filter (escaped)":
+    prefix: ":f"
+    body: '''
+      escaped:
+        $0
+    '''
+  "filter (javascript)":
+    prefix: ":f"
+    body: '''
+      javascript:
+        $0
+    '''
+  "filter (markdown)":
+    prefix: ":f"
+    body: '''
+      markdown:
+        $0
+    '''
+  "filter (plain)":
+    prefix: ":f"
+    body: '''
+      plain:
+        $0
+    '''
+  "filter (preserve)":
+    prefix: ":f"
+    body: '''
+      preserve:
+        $0
+    '''
+  "filter (ruby)":
+    prefix: ":f"
+    body: '''
+      ruby:
+        $0
+    '''
+  "filter (sass)":
+    prefix: ":f"
+    body: '''
+      sass:
+        $0
+    '''
+  "filter (textile)":
+    prefix: ":f"
+    body: '''
+      textile:
+        $0
+    '''
+  h1:
+    prefix: "h"
+    body: '''
+      h1 ${1:Heading Level 1}
+      $0
+    '''
+  h2:
+    prefix: "h"
+    body: '''
+      h2 ${1:Heading Level 2}
+      $0
+    '''
+  h3:
+    prefix: "h"
+    body: '''
+      h3 ${1:Heading Level 3}
+      $0
+    '''
+  h4:
+    prefix: "h"
+    body: '''
+      h4 ${1:Heading Level 4}
+      $0
+    '''
+  h5:
+    prefix: "h"
+    body: '''
+      h5 ${1:Heading Level 5}
+      $0
+    '''
+  h6:
+    prefix: "h"
+    body: '''
+      h6 ${1:Heading Level 6}
+      $0
+    '''
+  li:
+    prefix: "li"
+    body: "li ${5:Lorem ipsum...}$0"
+  "link_to (route)":
+    prefix: "="
+    body: "= link_to \"${1:Anchor Text}\", ${2:route}_url"
+  "link_to (url)":
+    prefix: "="
+    body: "= link_to \"${1:Anchor Text}\", \"${2:#}\""
+  "link_to (wrap selected text)":
+    prefix: "="
+    body: "= link_to \"Anchor text...\", ${1:\"${2:$0}\"}"
+  ol:
+    prefix: "ol"
+    body: '''
+      ol${1:#${2:selector}}
+        li ${3:Lorem ipsum dolor sit amet, consectetur adipisicing elit.}$0
+    '''
+  p:
+    prefix: "p"
+    body: "p ${1:Lorem ipsum...}"
+  render_partial:
+    prefix: "="
+    body: "= render partial=\"${1:partial_name}\""
+  span:
+    prefix: "s"
+    body: "span $0"
+  strong:
+    prefix: "s"
+    body: "strong $0"
+  "table (basic)":
+    prefix: "t"
+    body: '''
+      table
+        tr
+          td
+            ${1:Table Data}
+    '''
+  "table (templated)":
+    prefix: "t"
+    body: '''
+      table
+        thead
+          tr
+            th
+            ${1:Table Heading}
+        tbody
+          tr
+            td
+              ${2:Table Data}
+    '''
+  tbody:
+    prefix: "t"
+    body: '''
+      tbody
+        tr
+          td
+            ${1:Table Data} $0
+    '''
+  td:
+    prefix: "td"
+    body: "td $0"
+  tfooter:
+    prefix: "t"
+    body: '''
+      tfoot
+        tr
+          td
+            ${1:Table Data} $0
+    '''
+  th:
+    prefix: "th"
+    body: "th $0"
+  thead:
+    prefix: "t"
+    body: '''
+      thead
+        tr
+          th
+            ${1:Table Heading} $0
+    '''
+  tr:
+    prefix: "tr"
+    body: '''
+      tr
+        ${1:td}
+          ${2:Table Data} $0
+    '''
+  ul:
+    prefix: "ul"
+    body: '''
+      ul${1:#${2:selector}}
+        li ${3:Lorem ipsum dolor sit amet, consectetur adipisicing elit.}$0
+    '''


### PR DESCRIPTION
Recompiles the grammar from [ruby-slim.tmbundle](https://github.com/slim-template/ruby-slim.tmbundle). This update adds the definitions detailed in slim-template/ruby-slim.tmbundle#62, the resolved issues since that PR, and other reported issues:

#11 
#19 
#23 
#24 
#26

If you're chomping at the bit and willing to test this against your codebase, I'd be forever appreciative. Clone the [wip branch](https://github.com/slim-template/language-slim/tree/update-from-tmbundle) and run `apm link` in the new `language-slim` directory. Please report anything broken that wasn't broken before on this PR. 

I'll release a new version to `apm` after the weekend if all is well. 